### PR TITLE
Add fidelity (R²) computation to the LIME images notebook

### DIFF
--- a/xai-for-cnn/4-Tutorial_LIME_Images.ipynb
+++ b/xai-for-cnn/4-Tutorial_LIME_Images.ipynb
@@ -524,6 +524,31 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b3c9367d",
+   "metadata": {},
+   "source": [
+    "**Fidelity of the explanation**\n",
+    "\n",
+    "As in the Random Forest LIME notebook ([*Gen-2-Tutorial_LIME.ipynb*](../xai-for-random-forest/Gen-2-Tutorial_LIME.ipynb)), we can quantify how well the simple surrogate model approximates the predictions of the complex model in the neighborhood of our instance — the explanation's **fidelity**. LIME fits a weighted linear model on the perturbed images, and the goodness of fit of that surrogate is stored in `explanation.score` as an $R^2$ value (it refers to the top predicted class, i.e. the one we visualized above). The closer the $R^2$ is to 1, the better the surrogate reproduces the model's behavior on the neighborhood samples, and the more we can trust the explanation.\n",
+    "\n",
+    "*Note: for image data this $R^2$ is usually **considerably lower** than in the tabular Random Forest case. Approximating a deep CNN with a linear model over a few hundred on/off superpixel perturbations is a much coarser approximation than fitting a linear model to a handful of tabular features, so a modest value here is expected — it is a reminder to interpret image LIME explanations with extra caution, not a sign that something went wrong.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2e2ed760",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Fidelity of the local surrogate model: the R^2 of LIME's linear approximation\n",
+    "# for the top predicted class. As in the Random Forest notebook, values closer\n",
+    "# to 1 mean a better approximation; for image LIME this is typically lower.\n",
+    "explanation.score"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ad7f3d3f-f13c-44c1-b666-ba61777e4e34",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Adds a short **fidelity** section to `xai-for-cnn/4-Tutorial_LIME_Images.ipynb`, mirroring the treatment already in the Random Forest LIME notebook (`Gen-2-Tutorial_LIME.ipynb`).

## What it adds
Two cells at the end of the LIME walkthrough:
- A markdown cell explaining fidelity — how well LIMEs simple linear surrogate approximates the complex model in the neighborhood of the instance.
- A code cell (`explanation.score`) that reports the R² of that local surrogate for the top predicted class. Values closer to 1 mean a better local approximation; for image LIME this is typically lower.

## Notes
- **Diff is exactly the two cells** (+25 lines, no deletions); notebook metadata is unchanged from `main`.
- The change was originally made on the `2026-HIDA-Spring` course branch and tested there; it is cherry-picked onto a fresh branch off `main` here so it applies as a clean, minimal diff (the original branch also carried unrelated course-branch commits).