### PR TITLE
Fix the readthedocs build (drop the non-installable `pip install .` step)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,8 +21,5 @@ sphinx:
   
 # Optionally declare the Python requirements required to build your docs
 python:
-  # Install our python package before building the docs
   install:
-    - method: pip
-      path: .
     - requirements: docs/requirements.txt


### PR DESCRIPTION
The readthedocs site has not published since **19 May 2026** — every build since has failed. This fixes it.

## Cause
`setup.py` was removed on 2026-05-19 (commit `effe26b9`, "update docs configuration"), but `.readthedocs.yaml` still runs `pip install .`. With no `setup.py` or `pyproject.toml`, that step now errors and **aborts the build before Sphinx even runs**:

```
python -m pip install ... .
ERROR: Directory "." is not installable. Neither "setup.py" nor "pyproject.toml" found.
[exit-code: 1]
```

(Confirmed from the failed build log for commit `fbd53bf7`.)

## Fix
Remove the `pip install .` step from `.readthedocs.yaml`, keeping only `docs/requirements.txt`. The docs do not need the repo installed as a package — nothing uses `autodoc`/`autosummary` on the repo modules, and `conf.py` already adds the repo root to `sys.path`.

## Verified locally
Reproduced the RTD build (Python 3.10, `docs/requirements.txt`, `sphinx-build`) **without** the package-install step:
- `docs/requirements.txt` installs cleanly
- `sphinx-build` exits 0 — **build succeeded**, 17 HTML pages
- the transformer page renders all 9 embedded videos

## Follow-up (non-blocking)
The build still emits a few **non-fatal** warnings that do not stop publishing, worth a small later cleanup:
- `transformer.rst:482` — figure caption is a bullet list (renders wrong)
- `CNN_feature_visualization.rst:2` — title underline too short
- missing `_static/` dir; deprecated theme option `logo_only`

Happy to address those separately.